### PR TITLE
Add "Related actions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ jobs:
           id: preview-url
 ```
 
+## Related actions
+
+- [Action Comment Pull Request](https://github.com/thollander/actions-comment-pull-request) offers a similar functionality. Does not support failing, but offers reading the message from a file.
+- [GitHub Comment on PR](https://github.com/koppor/ghprcomment/) triggers comment based on failed workflows.
+
 ## Contributing
 
 Contributions are welcome :pray: Please [open an issue](https://github.com/hasura/comment-progress/issues/new) before working on something big or breaking.


### PR DESCRIPTION
I like friendly cross-linking of "related work" to ease users discovering other things which might be more fitting in their context.

In my setting, I needed a bot commenting after a workflow failed for contributors from forks. Thus, I could not use the GitHub token directly, because tokens from a fork don't have write permissions on issues. Therefore, I created [GitHub Comment on PR](https://github.com/koppor/ghprcomment/) , which I also included here 😇.